### PR TITLE
Add code of conduct and README linking to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Digital Oxford Code of Conduct
+
+[http://digitaloxford.github.io/code-of-conduct/](http://digitaloxford.github.io/code-of-conduct/)

--- a/index.html
+++ b/index.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Digital Oxford Code of Conduct</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
+    <style>body { font-size: 16px; line-height: 1.6; } p { margin-bottom: 20px; } h1, h2 { margin-bottom: 20px; }</style>
+  </head>
+
+  <body>
+    <div class="container">
+      <h1>Digital Oxford Code of Conduct</h1>
+
+      <h2>The quick version</h2>
+
+      <p>
+        The Digital Oxford Group is dedicated to providing a harassment-free community for everyone regardless of sex, gender identity or expression, sexual orientation, disability, physical appearance, age, body size, race, nationality, religious beliefs, or technology choices.
+        We do not tolerate harassment of community members in any form.
+        People violating these rules may be sanctioned or expelled from from Digital Oxford services or events at the discretion of the Digital Oxford staff.
+      </p>
+
+      <h2>The less quick version</h2>
+
+      <p>
+        Harassment includes offensive verbal or written comments related to sex, gender identity or expression, sexual orientation, disability, physical appearance, age, body size, race, nationality, religious beliefs, technology choices, deliberate intimidation, threats, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.
+        Sexual language and imagery is not appropriate for any Digital Oxford event or communication channel.
+        Harassment in online services extends to sending excessively large or numerous messages, or uploading offensive images or videos.
+      </p>
+
+      <p>
+        Everyone using Digital Oxford services or attending Digital Oxford events is subject to the anti-harassment policy; this includes sponsors, speakers, recruiters and organisers.
+        Anyone asked to stop any harassing behavior is expected to comply immediately.
+      </p>
+
+      <p>
+        If a community member engages in harassing behavior, the Digital Oxford staff may warn the offender or expel them from Digital Oxford services or events.
+        If you are being harassed, notice that someone else is being harassed, or have any other concerns; please contact a Digital Oxford organiser immediately.
+      </p>
+
+      <p>Digital Oxford staff may also provide an additional code of conduct for the needs of individual communication channels or events.</p>
+
+      <h2>Digital Oxford Slack administrators</h2>
+      <ul>
+        <li>Pete West (Slack: @peterjwest)</li>
+        <li>Max Glenister (Slack: @omgmog)</li>
+        <li>Beverley Newing (Slack: @beverley)</li>
+      </ul>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Mostly copied from the existing one (https://github.com/peterjwest/do-coc),
 with some minor rewording:
- "Participants" -> "People"
- "Organisers" -> "Staff"

Also replaced the list of organisers (very outdated) with a list of Slack administrators.
(These are people who actively administrate the Slack, not just everyone with admin rights)

I *think* the link should work once this is merged.